### PR TITLE
added writable flag to property descriptors

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,7 +296,8 @@
         if ( ! objectToExtend.prototype.hasOwnProperty(methodName) ) {
           Object.defineProperty( objectToExtend.prototype, methodName, {
             value: method,
-            enumerable: false
+            enumerable: false,
+            writable: true
           });
         }
       }


### PR DESCRIPTION
Because I like to live dangerously, I'm using agave without a prefix in an app I'm building. Because I don't like to live _that_ dangerously, I'm in strict mode. Unfortunately this combination means I can't define an `extend` property on any object, or use any libraries that do (Ractive being one but there are plenty others e.g. Backbone).

Wondered if you saw any downside to making the agave method descriptors writable? No problem if you'd rather keep it as is, of course.
