### PR TITLE
keep track of which prefixes agave has already been enabled for, prevent re-enabling

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,12 @@
   }
 }(this, function () {
 
+  var enabled = {};
+
   // Extend objects with Agave methods, using the prefix provided.
   var enable = function(prefix){
+    if ( enabled[prefix] ) return;
+
     var global = this;
 
     var SECONDS = 1000;
@@ -361,6 +365,8 @@
         addMethod(global, objectName, prefix, methodName, newMethods[objectName][methodName]);
       }
     }
+
+    enabled[prefix] = true;
   }.bind();
 
   // Just return a value to define the module export.


### PR DESCRIPTION
Just a small optimisation - if my app has dependencies which use Agave methods, those methods are called before the app initialises, and so they don't exist yet. The obvious solution is to `require` Agave at the top of each of those modules...

``` js
define( function ( require ) {
  'use strict';
  require( 'agave' ).enable();

  var someDependency = { /*...*/ };
  return someDependency;
});
```

...but that causes all the methods to be recreated unnecessarily. This commit short-circuits that, meaning I can sprinkle my modules with `require( 'agave' ).enable()` guilt-free.
