### PR TITLE
Number methods, plus [].remove(member)

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,6 +210,16 @@
       return fragment.childNodes;
     };
 
+    // Array remove removes an item from an array, if it exists
+    var arrayRemove = function (member){
+      var index = this.indexOf(member);
+      if (index !== -1 ) {
+        this.splice(index, 1);
+        return true;
+      }
+      return false;
+    };
+
     // Convert Number to (function name). +ensures type returned is still Number
     var seconds = function() {
       return +this * SECONDS;
@@ -242,6 +252,27 @@
     var after = function(date) {
       var time = getTimeOrNow(date);
       return new Date(time+(+this));
+    };
+
+    // Round Number
+    var round = function () {
+      return Math.round(this);
+    };
+
+    var ceil = function () {
+      return Math.ceil(this);
+    };
+
+    var floor = function () {
+      return Math.floor(this);
+    };
+
+    var abs = function () {
+      return Math.abs(this);
+    };
+
+    var pow = function (exp) {
+      return Math.pow(this, exp);
     };
 
     // Add a new element as a child of this element
@@ -346,7 +377,8 @@
         'extend':arrayExtend,
         'contains':contains,
         'clone':arrayClone,
-        'toNodeList':toNodeList
+        'toNodeList':toNodeList,
+        'remove':arrayRemove
       },
       'Object':{
         'getKeys':getKeys,
@@ -377,7 +409,12 @@
         'days':days,
         'weeks':weeks,
         'before':before,
-        'after':after
+        'after':after,
+        'round':round,
+        'ceil':ceil,
+        'floor':floor,
+        'abs':abs,
+        'pow':pow
       },
       'Element':{
         'createChild':createChild,

--- a/test/tests.js
+++ b/test/tests.js
@@ -153,6 +153,20 @@ describe('Array.findItem', function(){
   });
 });
 
+describe('Array.remove', function () {
+  it('correctly removes the given member', function (){
+    var arr = [1,2,3,4,5];
+    arr.avremove(3);
+    assert.deepEqual(arr, [1,2,4,5]);
+  });
+  if('returns true if the given member was in the array', function () {
+    assert.equal([1,2,3,4,5].remove(3), true);
+  });
+  if('returns false if the given member was not in the array', function () {
+    assert.equal([1,2,3,4,5].remove(6), false);
+  });
+});
+
 describe('Object.getPath', function(){
   it('returns undefined when a value is missing', function(){
     assert.equal(mockObject.avgetPath(['foo','pineapple']), undefined);
@@ -273,6 +287,41 @@ describe('Number.weeks.before and .after', function(){
     var someDate = new Date('Thu Jun 06 2013 22:44:05 GMT+0100 (UTC)');
     var timezoneOffset = someDate.getTimezoneOffset();
     assert.equal((3).avweeks().avafter(someDate).toLocaleDateString("en-GB", {timeZone:'UTC'}), 'Thursday, June 27, 2013');
+  });
+});
+
+describe('Number.round', function () {
+  var num = 4.2;
+  it('correctly rounds a number', function () {
+    assert.equal(num.avround(),4);
+  });
+});
+
+describe('Number.ceil', function () {
+  var num = 4.2;
+  it('correctly finds a number\'s ceiling', function () {
+    assert.equal(num.avceil(),5);
+  });
+});
+
+describe('Number.floor', function () {
+  var num = 4.2;
+  it('correctly finds a number\'s floor', function () {
+    assert.equal(num.avfloor(),4);
+  });
+});
+
+describe('Number.abs', function () {
+  var num = -4.2;
+  it('correctly finds the absolute value of a number', function () {
+    assert.equal(num.avabs(),4.2);
+  });
+});
+
+describe('Number.pow', function () {
+  var num = 5;
+  it('correctly raises a number to the given power', function () {
+    assert.equal(num.avpow(3), 125);
   });
 });
 


### PR DESCRIPTION
Hi Mike,

Just thought I'd see if you were interested in these methods I'd been using. `array.remove(member)` is something I need constantly, I don't really understand why it's not already part of the language. The number methods are just from `Math` - I like being able to do `num.round()` instead of `Math.round(num)`.

Have added tests but not docs, if you merge this (or part of it) I'll send a separate PR to gh-pages.

Cheers,

Rich
